### PR TITLE
Automatically initialize credentials

### DIFF
--- a/infra/concourse/build/developer-tools/Makefile
+++ b/infra/concourse/build/developer-tools/Makefile
@@ -26,3 +26,36 @@ release-image-developer-tools:
 	docker tag ${DOCKER_IMAGE_DEVELOPER_TOOLS}:${DOCKER_TAG_VERSION_DEVELOPER_TOOLS} \
   ${REGISTRY_URL}/${DOCKER_IMAGE_DEVELOPER_TOOLS}:${DOCKER_TAG_VERSION_DEVELOPER_TOOLS}
 	docker push ${REGISTRY_URL}/${DOCKER_IMAGE_DEVELOPER_TOOLS}:${DOCKER_TAG_VERSION_DEVELOPER_TOOLS}
+
+# The docker_run task is provided as an example and reference for other CFT
+# Terraform modules to use.  Each module should have an identical `make
+# docker_run` task in the module's repository.
+.PHONY: docker_run
+docker_run: ## Launch a shell within the Docker test environment
+	docker run --rm -it \
+		-e SERVICE_ACCOUNT_JSON \
+		-v $(CURDIR):/workspace \
+		cft/developer-tools:0.0.1 \
+		/bin/bash
+
+.PHONY: docker_test_lint
+docker_test_lint:
+	docker run --rm -it \
+		-v $(CURDIR):/workspace \
+		cft/developer-tools:0.0.1 \
+		make test_lint
+
+.PHONY: test_lint
+test_lint: check_shell check_headers check_python
+
+.PHONY: check_headers
+check_headers:
+	@source /usr/local/bin/task_helper_functions.sh && check_headers
+
+.PHONY: check_shell
+check_shell:
+	@source /usr/local/bin/task_helper_functions.sh && check_shell
+
+.PHONY: check_python
+check_python:
+	@source /usr/local/bin/task_helper_functions.sh && check_python

--- a/infra/concourse/build/developer-tools/README.md
+++ b/infra/concourse/build/developer-tools/README.md
@@ -1,0 +1,20 @@
+Developer Tools Image
+===
+
+See design decisions and discussion in [Common developer-tools container with
+credentials handling (DevEx 2.0)][design]
+
+Environment Variables
+===
+
+The following environment variables are inputs to the running container.
+Enviornment variables also implement feature flags to enable or disable
+behavior.  These variables are considered a public API and interface into the
+running container instance.
+
+| Environment Variable | Description |
+| --- | --- |
+| SERVICE_ACCOUNT_JSON | The JSON string content used to initialize credentials inside the container |
+| CFT_DISABLE_INIT_CREDENTIALS | Disables automatic initialization of credentials via ~root/.bashrc if the value has length '
+
+[design]: https://github.com/GoogleCloudPlatform/cloud-foundation-toolkit/issues/255

--- a/infra/concourse/build/developer-tools/build/home/bashrc
+++ b/infra/concourse/build/developer-tools/build/home/bashrc
@@ -1,1 +1,12 @@
 PS1='[\u@\h \W]\$ '
+
+if [[ -z "${CFT_DISABLE_INIT_CREDENTIALS:-}" ]]; then
+  echo 'Loading /usr/local/bin/task_helper_functions.sh from ~/.bashrc' >&2
+  echo 'Disable by setting CFT_DISABLE_INIT_CREDENTIALS to a non-empty value' >&2
+  # shellcheck disable=1091
+  source /usr/local/bin/task_helper_functions.sh
+  init_credentials
+else
+  echo -n 'Skipping init_credentials because CFT_DISABLE_INIT_CREDENTIALS ' >&2
+  echo 'has length' >&2
+fi


### PR DESCRIPTION
Without this patch credentials aren't automatically initialized.  This
patch automatically initializes credentials for the purpose of
interactive development.  Developers should enter the container and be
able to work with the integration tests:

    make docker_run

A feature flag allows the automatic behavior to be disabled for certain
use cases:

 1. Working on the init_credentials function itself
 2. Troubleshooting the behavior of the init_credentials function
 3. Tasks which don't require credentials (e.g. lint, unit, and document
    generation).